### PR TITLE
Solve #10, #11, add some additional features

### DIFF
--- a/denim.nimble
+++ b/denim.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.7"
+version       = "0.1.8"
 author        = "George Lemon"
 description   = "DENIM - Nim code to Bun.js/Node.js in seconds via NAPI"
 license       = "MIT"


### PR DESCRIPTION
- Fix `toObject` for runtime values (https://github.com/openpeeps/denim/pull/12/files#diff-86d904107e74d06b80c6f7718203ca025fec0ece6d8f39e2eeefa53877562214R226)
- Add `hasOwnProperty` procedure (https://github.com/openpeeps/denim/pull/12/files#diff-86d904107e74d06b80c6f7718203ca025fec0ece6d8f39e2eeefa53877562214R316-R321)
- fix `callFunction` proc (#10) (https://github.com/openpeeps/denim/pull/12/files#diff-86d904107e74d06b80c6f7718203ca025fec0ece6d8f39e2eeefa53877562214R450)
- improve `callMethod` proc (https://github.com/openpeeps/denim/pull/12/files#diff-86d904107e74d06b80c6f7718203ca025fec0ece6d8f39e2eeefa53877562214R455)
- `export_napi` now works with Nim 2.0.0 (#11) (https://github.com/openpeeps/denim/pull/12/files#diff-86d904107e74d06b80c6f7718203ca025fec0ece6d8f39e2eeefa53877562214R581-R601)
- add some methods to work with `napi_coerce_to...` (https://github.com/openpeeps/denim/pull/12/files#diff-86d904107e74d06b80c6f7718203ca025fec0ece6d8f39e2eeefa53877562214R722-R732)
- `napi_get_property_names` (https://github.com/openpeeps/denim/pull/12/files#diff-86d904107e74d06b80c6f7718203ca025fec0ece6d8f39e2eeefa53877562214R735-R747)
- `pairs` iterator for `napi_object` (https://github.com/openpeeps/denim/pull/12/files#diff-86d904107e74d06b80c6f7718203ca025fec0ece6d8f39e2eeefa53877562214R758-R762)
- convenient `$` nim proc (https://github.com/openpeeps/denim/pull/12/files#diff-86d904107e74d06b80c6f7718203ca025fec0ece6d8f39e2eeefa53877562214R770-R786)