### PR TITLE
Some cool features

### DIFF
--- a/src/denimpkg/napi/bindings.nim
+++ b/src/denimpkg/napi/bindings.nim
@@ -554,6 +554,22 @@ proc getNimNapiType(n: NimNode, countless: var bool): tuple[nimArgType, napiArgT
     error("Cannot convert to NapiValueType", n)
 
 
+macro export_napi*(vName, vType: untyped, vVal: typed) =
+  ## A fancy compile-time macro to export object properties
+  ## ```nim
+  ## var name {.export_napi.} = "Denim is Awesome!"
+  ## ```
+  expectKind(vName, nnkIdent)
+  result = newStmtList()
+  result.add(
+    newCall(
+      ident("register"),
+      ident("module"),
+      newLit(vName.strVal),
+      vVal
+    )
+  )
+
 macro export_napi*(fn: untyped, withModule: untyped = nil) =
   ## A fancy compile-time macro to export NAPI functions
   ## 


### PR DESCRIPTION
Now developers can use `napi_value` with clean syntax:
```nim
var x = toObject({
  "hello": "world"
})
echo x.hello
x.hello = "world!!!!"
var y = toJsObject([
  1, 2, 3, 4
])
echo y.pop()
echo y
```

Result is
```
world
4
[1,2,3]
```